### PR TITLE
Implement `Clone` and `Debug` for `Iter`

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -3,6 +3,7 @@ use core::hash::{BuildHasher, Hash};
 use std::iter::{FromIterator, IntoIterator};
 
 /// Iterator over the key value pairs of a Halfbrown map
+#[derive(Clone, Debug)]
 pub struct Iter<'a, K, V>(IterInt<'a, K, V>);
 
 impl<'a, K, V> From<IterInt<'a, K, V>> for Iter<'a, K, V> {
@@ -10,6 +11,7 @@ impl<'a, K, V> From<IterInt<'a, K, V>> for Iter<'a, K, V> {
         Self(i)
     }
 }
+#[derive(Clone, Debug)]
 pub(crate) enum IterInt<'a, K, V> {
     Map(hashbrown::hash_map::Iter<'a, K, V>),
     Vec(std::slice::Iter<'a, (K, V)>),


### PR DESCRIPTION
<!--
Read the [contributing guidelines](https://github.com/get-alex/.github/blob/master/contributing.md).

We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.

If this fixes an open issue, link to it in the following way: `Closes GH-123`.

New features and bug fixes should come with tests.

P.S. have you seen our support and contributing docs?
https://github.com/get-alex/.github/blob/master/support.md
https://github.com/get-alex/.github/blob/master/contributing.md
-->

The type differs from `hashbrown`'s otherwise:

* https://docs.rs/halfbrown/latest/halfbrown/struct.Iter.html
* https://docs.rs/hashbrown/latest/hashbrown/hash_map/struct.Iter.html
