### PR TITLE
Same `Default` constraints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ pub const VEC_LIMIT_UPPER: usize = 32;
 #[derive(Clone)]
 pub struct HashMap<K, V, S = DefaultHashBuilder>(HashMapInt<K, V, S>);
 
-impl<K: Default, V: Default> Default for HashMap<K, V, DefaultHashBuilder> {
+impl<K, V, S: Default> Default for HashMap<K, V, S> {
     #[inline]
     fn default() -> Self {
         Self(HashMapInt::default())
@@ -89,11 +89,7 @@ enum HashMapInt<K, V, S = DefaultHashBuilder> {
     None,
 }
 
-impl<K, V> Default for HashMapInt<K, V, DefaultHashBuilder>
-where
-    K: Default,
-    V: Default,
-{
+impl<K, V, S: Default> Default for HashMapInt<K, V, S> {
     #[inline]
     fn default() -> Self {
         Self::Vec(VecMap::default())

--- a/src/vecmap.rs
+++ b/src/vecmap.rs
@@ -14,12 +14,12 @@ pub(crate) struct VecMap<K, V, S = DefaultHashBuilder> {
     hash_builder: S,
 }
 
-impl<K, V> Default for VecMap<K, V, DefaultHashBuilder> {
+impl<K, V, S: Default> Default for VecMap<K, V, S> {
     #[inline]
     fn default() -> Self {
         Self {
             v: Vec::new(),
-            hash_builder: DefaultHashBuilder::default(),
+            hash_builder: S::default(),
         }
     }
 }


### PR DESCRIPTION
This PR makes the constraints for the `Default` implementation the exact same as `hashbrown`'s