### PR TITLE
Add or_default to entry

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -135,7 +135,34 @@ impl<'a, K, V, S> Entry<'a, K, V, S> {
         }
     }
 }
-
+impl<'a, K, V: Default, S> Entry<'a, K, V, S> {
+    /// Ensures a value is in the entry by inserting the default value if empty,
+    /// and returns a mutable reference to the value in the entry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # fn main() {
+    /// use halfbrown::HashMap;
+    ///
+    /// let mut map: HashMap<&str, Option<u32>> = HashMap::new();
+    /// map.entry("poneyland").or_default();
+    ///
+    /// assert_eq!(map["poneyland"], None);
+    /// # }
+    /// ```
+    #[inline]
+    pub fn or_default(self) -> &'a mut V
+    where
+        K: Hash,
+        S: BuildHasher,
+    {
+        match self {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => entry.insert(Default::default()),
+        }
+    }
+}
 impl<'a, K, V, S> From<HashBrownEntry<'a, K, V, S>> for Entry<'a, K, V, S> {
     fn from(f: HashBrownEntry<'a, K, V, S>) -> Entry<'a, K, V, S> {
         match f {


### PR DESCRIPTION
Hi,

I added the or_default function to Entry that is  [available in the standard library](https://doc.rust-lang.org/std/collections/hash_map/enum.Entry.html#method.or_default) because Rust 1.65 added a new [clippy lint](https://rust-lang.github.io/rust-clippy/master/index.html#or_fun_call) that complains if you do or_insert(Something::new()) instead of or_default.

The code is almost 1:1 copied from the standard library. I hope that's not a copyright issue (I don't know anything about licenses)

PS: Thanks for the cool library