### PR TITLE
Use rustc-hash for fxhash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ repository = "https://github.com/Licenser/halfbrown"
 version = "0.1.18"
 
 [dependencies]
-fxhash = { version = "0.2", optional = true }
 hashbrown = "0.13"
+rustc-hash = { version = "1.1", optional = true }
 serde = { version = "1", default-features = false, optional = true }
 
 [dev-dependencies]
@@ -18,6 +18,7 @@ criterion = "0.4"
 
 [features]
 default = []
+fxhash = ["rustc-hash"]
 
 [[bench]]
 harness = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,8 @@ use std::fmt::{self, Debug};
 use std::ops::Index;
 
 #[cfg(feature = "fxhash")]
-pub use fxhash::FxBuildHasher as DefaultHashBuilder;
+/// Default hasher
+pub type DefaultHashBuilder = core::hash::BuildHasherDefault<rustc_hash::FxHasher>;
 #[cfg(not(feature = "fxhash"))]
 pub use hashbrown::hash_map::DefaultHashBuilder;
 


### PR DESCRIPTION
Hi, thanks for this project!

This switches the `fxhash` feature to use the crate that Rust uses for fx hashing: https://github.com/rust-lang/rustc-hash

Related discussion: https://github.com/cbreeden/fxhash/issues/10