### PR TITLE
Implement ExactSizeIterator,FusedIterator, Fix new clippy lints

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -219,8 +219,8 @@ where
 impl<K: fmt::Debug, V: fmt::Debug, S> fmt::Debug for OccupiedEntry<'_, K, V, S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.0 {
-            OccupiedEntryInt::Map(m) => write!(f, "{:?}", m),
-            OccupiedEntryInt::Vec(m) => write!(f, "{:?}", m),
+            OccupiedEntryInt::Map(m) => write!(f, "{m:?}"),
+            OccupiedEntryInt::Vec(m) => write!(f, "{m:?}"),
         }
     }
 }
@@ -241,8 +241,8 @@ enum VacantEntryInt<'a, K, V, S> {
 impl<K: fmt::Debug, V, S> fmt::Debug for VacantEntry<'_, K, V, S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.0 {
-            VacantEntryInt::Map(m) => write!(f, "{:?}", m),
-            VacantEntryInt::Vec(m) => write!(f, "{:?}", m),
+            VacantEntryInt::Map(m) => write!(f, "{m:?}"),
+            VacantEntryInt::Vec(m) => write!(f, "{m:?}"),
         }
     }
 }


### PR DESCRIPTION
Hi,

The corresponding iter structs of map and vec implement the traits ExactSizeIterator and FusedIterator so I've added these traits for the halfbrown map iter structs as well.

Furthermore, clippy now complains if you write `format!("{}",x}` instead of `format!("{x}"}` and I fixed that  as well.