### PR TITLE
Stackbackend

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,3 +27,7 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Build arraybackend feature
+      run: cargo build --features arraybackend --verbose
+    - name: Run tests arraybackend feature
+      run: cargo test --features arraybackend --verbose

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-      
+
 jobs:
   clippy_check:
     runs-on: ubuntu-latest
@@ -36,7 +36,7 @@ jobs:
       - name: install tarpaulin
         run: cargo install cargo-tarpaulin -f
       - name: run tarpaulin
-        run: cargo tarpaulin --out Xml 
+        run: cargo tarpaulin --out Xml
       - uses: codecov/codecov-action@v3
         with:
           #token: ${{secrets.CODECOV_TOKEN}} not needed for public repos

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.1.18"
 hashbrown = "0.13"
 rustc-hash = { version = "1.1", optional = true }
 serde = { version = "1", default-features = false, optional = true }
-
+arrayvec = {version = "0.7", optional = true}
 [dev-dependencies]
 criterion = "0.4"
 
@@ -19,6 +19,7 @@ criterion = "0.4"
 [features]
 default = []
 fxhash = ["rustc-hash"]
+arraybackend = ["arrayvec"]
 
 [[bench]]
 harness = false

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -18,15 +18,15 @@ use std::fmt;
 ///
 /// [`HashMap`]: struct.HashMap.html
 /// [`entry`]: struct.HashMap.html#method.entry
-pub enum Entry<'a, K, V, S> {
+pub enum Entry<'a, K, V, const N: usize, S> {
     /// An occupied entry.
-    Occupied(OccupiedEntry<'a, K, V, S>),
+    Occupied(OccupiedEntry<'a, K, V, N, S>),
 
     /// A vacant entry.
-    Vacant(VacantEntry<'a, K, V, S>),
+    Vacant(VacantEntry<'a, K, V, N, S>),
 }
 
-impl<'a, K, V, S> Entry<'a, K, V, S> {
+impl<'a, K, V, const N: usize, S> Entry<'a, K, V, N, S> {
     /// Ensures a value is in the entry by inserting the default if empty, and returns
     /// a mutable reference to the value in the entry.
     ///
@@ -135,7 +135,7 @@ impl<'a, K, V, S> Entry<'a, K, V, S> {
         }
     }
 }
-impl<'a, K, V: Default, S> Entry<'a, K, V, S> {
+impl<'a, K, V: Default, const N: usize, S> Entry<'a, K, V, N, S> {
     /// Ensures a value is in the entry by inserting the default value if empty,
     /// and returns a mutable reference to the value in the entry.
     ///
@@ -163,8 +163,8 @@ impl<'a, K, V: Default, S> Entry<'a, K, V, S> {
         }
     }
 }
-impl<'a, K, V, S> From<HashBrownEntry<'a, K, V, S>> for Entry<'a, K, V, S> {
-    fn from(f: HashBrownEntry<'a, K, V, S>) -> Entry<'a, K, V, S> {
+impl<'a, K, V, const N: usize, S> From<HashBrownEntry<'a, K, V, S>> for Entry<'a, K, V, N, S> {
+    fn from(f: HashBrownEntry<'a, K, V, S>) -> Entry<'a, K, V, N, S> {
         match f {
             HashBrownEntry::Occupied(o) => Entry::Occupied(OccupiedEntry(OccupiedEntryInt::Map(o))),
             HashBrownEntry::Vacant(o) => Entry::Vacant(VacantEntry(VacantEntryInt::Map(o))),
@@ -172,8 +172,8 @@ impl<'a, K, V, S> From<HashBrownEntry<'a, K, V, S>> for Entry<'a, K, V, S> {
     }
 }
 
-impl<'a, K, V, S> From<VecMapEntry<'a, K, V, S>> for Entry<'a, K, V, S> {
-    fn from(f: VecMapEntry<'a, K, V, S>) -> Entry<'a, K, V, S> {
+impl<'a, K, V, const N: usize, S> From<VecMapEntry<'a, K, V, N, S>> for Entry<'a, K, V, N, S> {
+    fn from(f: VecMapEntry<'a, K, V, N, S>) -> Entry<'a, K, V, N, S> {
         match f {
             VecMapEntry::Occupied(o) => Entry::Occupied(OccupiedEntry(OccupiedEntryInt::Vec(o))),
             VecMapEntry::Vacant(o) => Entry::Vacant(VacantEntry(VacantEntryInt::Vec(o))),
@@ -181,7 +181,7 @@ impl<'a, K, V, S> From<VecMapEntry<'a, K, V, S>> for Entry<'a, K, V, S> {
     }
 }
 
-impl<K: fmt::Debug, V: fmt::Debug, S> fmt::Debug for Entry<'_, K, V, S> {
+impl<K: fmt::Debug, V: fmt::Debug, const N: usize, S> fmt::Debug for Entry<'_, K, V, N, S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Entry::Vacant(ref v) => f.debug_tuple("Entry").field(v).finish(),
@@ -194,21 +194,21 @@ impl<K: fmt::Debug, V: fmt::Debug, S> fmt::Debug for Entry<'_, K, V, S> {
 /// It is part of the [`Entry`] enum.
 ///
 /// [`Entryx`]: enum.Entry.html
-pub struct OccupiedEntry<'a, K, V, S>(OccupiedEntryInt<'a, K, V, S>);
+pub struct OccupiedEntry<'a, K, V, const N: usize, S>(OccupiedEntryInt<'a, K, V, S, N>);
 
-enum OccupiedEntryInt<'a, K, V, S> {
+enum OccupiedEntryInt<'a, K, V, S, const N: usize> {
     Map(hash_map::OccupiedEntry<'a, K, V, S>),
-    Vec(vecmap::OccupiedEntry<'a, K, V, S>),
+    Vec(vecmap::OccupiedEntry<'a, K, V, S, N>),
 }
 
-unsafe impl<K, V, S> Send for OccupiedEntry<'_, K, V, S>
+unsafe impl<K, V, const N: usize, S> Send for OccupiedEntry<'_, K, V, N, S>
 where
     K: Send,
     V: Send,
     S: Send,
 {
 }
-unsafe impl<K, V, S> Sync for OccupiedEntry<'_, K, V, S>
+unsafe impl<K, V, const N: usize, S> Sync for OccupiedEntry<'_, K, V, N, S>
 where
     K: Sync,
     V: Sync,
@@ -216,7 +216,7 @@ where
 {
 }
 
-impl<K: fmt::Debug, V: fmt::Debug, S> fmt::Debug for OccupiedEntry<'_, K, V, S> {
+impl<K: fmt::Debug, V: fmt::Debug, const N: usize, S> fmt::Debug for OccupiedEntry<'_, K, V, N, S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.0 {
             OccupiedEntryInt::Map(m) => m.fmt(f),
@@ -229,16 +229,16 @@ impl<K: fmt::Debug, V: fmt::Debug, S> fmt::Debug for OccupiedEntry<'_, K, V, S> 
 /// It is part of the [`Entry`] enum.
 ///
 /// [`Entry`]: enum.Entry.html
-pub struct VacantEntry<'a, K, V, S>(VacantEntryInt<'a, K, V, S>);
+pub struct VacantEntry<'a, K, V, const N: usize, S>(VacantEntryInt<'a, K, V, N, S>);
 
-enum VacantEntryInt<'a, K, V, S> {
+enum VacantEntryInt<'a, K, V, const N: usize, S> {
     /// a map based implementation
     Map(hashbrown::hash_map::VacantEntry<'a, K, V, S>),
     /// a vec based implementation
-    Vec(vecmap::VacantEntry<'a, K, V, S>),
+    Vec(vecmap::VacantEntry<'a, K, V, N, S>),
 }
 
-impl<K: fmt::Debug, V, S> fmt::Debug for VacantEntry<'_, K, V, S> {
+impl<K: fmt::Debug, V, const N: usize, S> fmt::Debug for VacantEntry<'_, K, V, N, S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.0 {
             VacantEntryInt::Map(m) => m.fmt(f),
@@ -247,7 +247,7 @@ impl<K: fmt::Debug, V, S> fmt::Debug for VacantEntry<'_, K, V, S> {
     }
 }
 
-impl<'a, K, V, S> OccupiedEntry<'a, K, V, S> {
+impl<'a, K, V, const N: usize, S> OccupiedEntry<'a, K, V, N, S> {
     /// Gets a reference to the key in the entry.
     ///
     /// # Examples
@@ -493,7 +493,7 @@ impl<'a, K, V, S> OccupiedEntry<'a, K, V, S> {
     }
 }
 
-impl<'a, K, V, S> VacantEntry<'a, K, V, S> {
+impl<'a, K, V, const N: usize, S> VacantEntry<'a, K, V, N, S> {
     /// Gets a reference to the key that would be used when inserting a value
     /// through the `VacantEntry`.
     ///

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,4 +1,5 @@
 use super::{HashMapInt, SizedHashMap};
+use crate::vectypes::VecIntoIter;
 use core::hash::{BuildHasher, Hash};
 use std::iter::{FromIterator, FusedIterator, IntoIterator};
 
@@ -72,14 +73,14 @@ impl<'a, K, V> ExactSizeIterator for Iter<'a, K, V> {
 impl<'a, K, V> FusedIterator for Iter<'a, K, V> {}
 
 /// Into iterator for a Halfbrown map
-pub struct IntoIter<K, V>(IntoIterInt<K, V>);
+pub struct IntoIter<K, V, const N: usize>(IntoIterInt<K, V, N>);
 
-enum IntoIterInt<K, V> {
+enum IntoIterInt<K, V, const N: usize> {
     Map(hashbrown::hash_map::IntoIter<K, V>),
-    Vec(std::vec::IntoIter<(K, V)>),
+    Vec(VecIntoIter<(K, V), N>),
 }
 
-impl<K, V> IntoIter<K, V> {
+impl<K, V, const N: usize> IntoIter<K, V, N> {
     /// The length of this iterator
     #[must_use]
     pub fn len(&self) -> usize {
@@ -95,7 +96,7 @@ impl<K, V> IntoIter<K, V> {
     }
 }
 
-impl<K, V> Iterator for IntoIter<K, V> {
+impl<K, V, const N: usize> Iterator for IntoIter<K, V, N> {
     type Item = (K, V);
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -113,7 +114,7 @@ impl<K, V> Iterator for IntoIter<K, V> {
     }
 }
 
-impl<K, V> ExactSizeIterator for IntoIter<K, V> {
+impl<K, V, const N: usize> ExactSizeIterator for IntoIter<K, V, N> {
     #[inline]
     fn len(&self) -> usize {
         match &self.0 {
@@ -123,14 +124,14 @@ impl<K, V> ExactSizeIterator for IntoIter<K, V> {
     }
 }
 
-impl<K, V> FusedIterator for IntoIter<K, V> {}
+impl<K, V, const N: usize> FusedIterator for IntoIter<K, V, N> {}
 
-impl<K, V, S> IntoIterator for SizedHashMap<K, V, S> {
+impl<K, V, const N: usize, S> IntoIterator for SizedHashMap<K, V, S, N> {
     type Item = (K, V);
-    type IntoIter = IntoIter<K, V>;
+    type IntoIter = IntoIter<K, V, N>;
 
     #[inline]
-    fn into_iter(self) -> IntoIter<K, V> {
+    fn into_iter(self) -> IntoIter<K, V, N> {
         match self.0 {
             HashMapInt::Map(m) => IntoIter(IntoIterInt::Map(m.into_iter())),
             HashMapInt::Vec(m) => IntoIter(IntoIterInt::Vec(m.into_iter())),

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -135,7 +135,6 @@ impl<K, V, const N: usize, S> IntoIterator for SizedHashMap<K, V, S, N> {
         match self.0 {
             HashMapInt::Map(m) => IntoIter(IntoIterInt::Map(m.into_iter())),
             HashMapInt::Vec(m) => IntoIter(IntoIterInt::Vec(m.into_iter())),
-            HashMapInt::None => unreachable!(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,6 @@ where
 enum HashMapInt<K, V, const N: usize, S = DefaultHashBuilder> {
     Map(HashBrown<K, V, S>),
     Vec(VecMap<K, V, N, S>),
-    None,
 }
 
 impl<K, V, const N: usize, S: Default> Default for HashMapInt<K, V, N, S> {
@@ -239,7 +238,6 @@ impl<K, V, S, const VEC_LIMIT_UPPER: usize> SizedHashMap<K, V, S, VEC_LIMIT_UPPE
         match &self.0 {
             HashMapInt::Map(m) => m.hasher(),
             HashMapInt::Vec(m) => m.hasher(),
-            HashMapInt::None => unreachable!(),
         }
     }
 
@@ -261,7 +259,6 @@ impl<K, V, S, const VEC_LIMIT_UPPER: usize> SizedHashMap<K, V, S, VEC_LIMIT_UPPE
         match &self.0 {
             HashMapInt::Map(m) => m.capacity(),
             HashMapInt::Vec(m) => m.capacity(),
-            HashMapInt::None => unimplemented!(),
         }
     }
 
@@ -356,7 +353,6 @@ impl<K, V, S, const VEC_LIMIT_UPPER: usize> SizedHashMap<K, V, S, VEC_LIMIT_UPPE
         match &self.0 {
             HashMapInt::Map(m) => IterInt::Map(m.iter()).into(),
             HashMapInt::Vec(m) => IterInt::Vec(m.iter()).into(),
-            HashMapInt::None => unreachable!(),
         }
     }
 
@@ -387,7 +383,6 @@ impl<K, V, S, const VEC_LIMIT_UPPER: usize> SizedHashMap<K, V, S, VEC_LIMIT_UPPE
         match &mut self.0 {
             HashMapInt::Map(m) => IterMutInt::Map(m.iter_mut()).into(),
             HashMapInt::Vec(m) => IterMutInt::Vec(m.iter_mut()).into(),
-            HashMapInt::None => unreachable!(),
         }
     }
 
@@ -408,7 +403,6 @@ impl<K, V, S, const VEC_LIMIT_UPPER: usize> SizedHashMap<K, V, S, VEC_LIMIT_UPPE
         match &self.0 {
             HashMapInt::Map(m) => m.len(),
             HashMapInt::Vec(m) => m.len(),
-            HashMapInt::None => unreachable!(),
         }
     }
 
@@ -429,7 +423,6 @@ impl<K, V, S, const VEC_LIMIT_UPPER: usize> SizedHashMap<K, V, S, VEC_LIMIT_UPPE
         match &self.0 {
             HashMapInt::Map(m) => m.is_empty(),
             HashMapInt::Vec(m) => m.is_empty(),
-            HashMapInt::None => unreachable!(),
         }
     }
 
@@ -457,7 +450,6 @@ impl<K, V, S, const VEC_LIMIT_UPPER: usize> SizedHashMap<K, V, S, VEC_LIMIT_UPPE
         match &mut self.0 {
             HashMapInt::Map(m) => Drain(DrainInt::Map(m.drain())),
             HashMapInt::Vec(m) => Drain(DrainInt::Vec(m.drain())),
-            HashMapInt::None => unreachable!(),
         }
     }
 
@@ -479,7 +471,6 @@ impl<K, V, S, const VEC_LIMIT_UPPER: usize> SizedHashMap<K, V, S, VEC_LIMIT_UPPE
         match &mut self.0 {
             HashMapInt::Map(m) => m.clear(),
             HashMapInt::Vec(m) => m.clear(),
-            HashMapInt::None => unreachable!(),
         }
     }
 }
@@ -511,7 +502,6 @@ where
         match &mut self.0 {
             HashMapInt::Map(m) => m.reserve(additional),
             HashMapInt::Vec(m) => m.reserve(additional),
-            HashMapInt::None => unreachable!(),
         }
     }
     /*
@@ -537,7 +527,6 @@ where
         match &mut self.0 {
             HashMapInt::Map(m) => m.try_reserve(additional),
             HashMapInt::Vec(m) => m.try_reserve(additional),
-            HashMapInt::None => unreachable!(),
         }
     }
     */
@@ -561,7 +550,6 @@ where
         match &mut self.0 {
             HashMapInt::Map(m) => m.shrink_to_fit(),
             HashMapInt::Vec(m) => m.shrink_to_fit(),
-            HashMapInt::None => unreachable!(),
         }
     }
 
@@ -596,7 +584,6 @@ where
         match &mut self.0 {
             HashMapInt::Map(m) => m.entry(key).into(),
             HashMapInt::Vec(m) => m.entry(key).into(),
-            HashMapInt::None => unreachable!(),
         }
     }
 
@@ -628,7 +615,6 @@ where
         match &self.0 {
             HashMapInt::Map(m) => m.get(k),
             HashMapInt::Vec(m) => m.get(k),
-            HashMapInt::None => unreachable!(),
         }
     }
 
@@ -659,7 +645,6 @@ where
         match &self.0 {
             HashMapInt::Map(m) => m.contains_key(k),
             HashMapInt::Vec(m) => m.contains_key(k),
-            HashMapInt::None => unreachable!(),
         }
     }
 
@@ -693,23 +678,25 @@ where
         match &mut self.0 {
             HashMapInt::Map(m) => m.get_mut(k),
             HashMapInt::Vec(m) => m.get_mut(k),
-            HashMapInt::None => unreachable!(),
         }
     }
     fn swap_backend_to_map(&mut self) -> &mut hashbrown::HashMap<K, V, S>
     where
         S: Default,
     {
-        self.0 = match std::mem::replace(&mut self.0, HashMapInt::None) {
-            HashMapInt::Vec(mut m) => {
+        self.0 = match &mut self.0 {
+            HashMapInt::Vec(m) => {
                 let m1: HashBrown<K, V, S> = m.drain().collect();
                 HashMapInt::Map(m1)
             }
-            _ => unreachable!(),
+            HashMapInt::Map(_) => {
+                unreachable!()
+            }
         };
+
         match &mut self.0 {
             HashMapInt::Map(m) => m,
-            _ => {
+            HashMapInt::Vec(_) => {
                 unreachable!()
             }
         }
@@ -754,7 +741,6 @@ where
                     m.insert(k, v)
                 }
             }
-            HashMapInt::None => unreachable!(),
         }
     }
 
@@ -787,7 +773,6 @@ where
         match &mut self.0 {
             HashMapInt::Map(m) => m.remove(k),
             HashMapInt::Vec(m) => m.remove(k),
-            HashMapInt::None => unreachable!(),
         }
     }
 
@@ -820,7 +805,6 @@ where
         match &mut self.0 {
             HashMapInt::Map(m) => m.remove_entry(k),
             HashMapInt::Vec(m) => m.remove_entry(k),
-            HashMapInt::None => unreachable!(),
         }
     }
 
@@ -846,7 +830,6 @@ where
         match &mut self.0 {
             HashMapInt::Map(m) => m.retain(f),
             HashMapInt::Vec(m) => m.retain(f),
-            HashMapInt::None => unreachable!(),
         }
     }
 
@@ -870,7 +853,6 @@ where
                     m.insert_nocheck(k, v);
                 }
             }
-            HashMapInt::None => unreachable!(),
         }
     }
 
@@ -880,7 +862,6 @@ where
         match &self.0 {
             HashMapInt::Map(_m) => true,
             HashMapInt::Vec(_m) => false,
-            HashMapInt::None => unreachable!(),
         }
     }
 
@@ -890,7 +871,6 @@ where
         match &self.0 {
             HashMapInt::Map(_m) => false,
             HashMapInt::Vec(_m) => true,
-            HashMapInt::None => unreachable!(),
         }
     }
 }
@@ -963,7 +943,6 @@ where
         match &mut self.0 {
             HashMapInt::Vec(m) => RawEntryBuilderMut::from(m.raw_entry_mut()),
             HashMapInt::Map(m) => RawEntryBuilderMut::from(m.raw_entry_mut()),
-            HashMapInt::None => unreachable!(),
         }
     }
 
@@ -987,7 +966,6 @@ where
         match &self.0 {
             HashMapInt::Vec(m) => RawEntryBuilder::from(m.raw_entry()),
             HashMapInt::Map(m) => RawEntryBuilder::from(m.raw_entry()),
-            HashMapInt::None => unreachable!(),
         }
     }
 }

--- a/src/raw_entry.rs
+++ b/src/raw_entry.rs
@@ -13,27 +13,29 @@ use std::mem;
 /// See the [`HashMap::raw_entry_mut`] docs for usage examples.
 ///
 /// [`HashMap::raw_entry_mut`]: struct.HashMap.html#method.raw_entry_mut
-pub struct RawEntryBuilderMut<'map, K, V, S>(RawEntryBuilderMutInt<'map, K, V, S>);
+pub struct RawEntryBuilderMut<'map, K, V, const N: usize, S>(
+    RawEntryBuilderMutInt<'map, K, V, N, S>,
+);
 
-impl<'map, K, V, S> From<hash_map::RawEntryBuilderMut<'map, K, V, S>>
-    for RawEntryBuilderMut<'map, K, V, S>
+impl<'map, K, V, const N: usize, S> From<hash_map::RawEntryBuilderMut<'map, K, V, S>>
+    for RawEntryBuilderMut<'map, K, V, N, S>
 {
     fn from(m: hash_map::RawEntryBuilderMut<'map, K, V, S>) -> Self {
         Self(RawEntryBuilderMutInt::Map(m))
     }
 }
 
-impl<'map, K, V, S> From<vecmap::RawEntryBuilderMut<'map, K, V, S>>
-    for RawEntryBuilderMut<'map, K, V, S>
+impl<'map, K, V, const N: usize, S> From<vecmap::RawEntryBuilderMut<'map, K, V, N, S>>
+    for RawEntryBuilderMut<'map, K, V, N, S>
 where
     S: BuildHasher,
 {
-    fn from(m: vecmap::RawEntryBuilderMut<'map, K, V, S>) -> Self {
+    fn from(m: vecmap::RawEntryBuilderMut<'map, K, V, N, S>) -> Self {
         Self(RawEntryBuilderMutInt::Vec(m))
     }
 }
-enum RawEntryBuilderMutInt<'map, K, V, S> {
-    Vec(vecmap::RawEntryBuilderMut<'map, K, V, S>),
+enum RawEntryBuilderMutInt<'map, K, V, const N: usize, S> {
+    Vec(vecmap::RawEntryBuilderMut<'map, K, V, N, S>),
     Map(hash_map::RawEntryBuilderMut<'map, K, V, S>),
 }
 
@@ -48,15 +50,17 @@ enum RawEntryBuilderMutInt<'map, K, V, S> {
 /// [`Entry`]: enum.Entry.html
 /// [`raw_entry_mut`]: struct.HashMap.html#method.raw_entry_mut
 /// [`RawEntryBuilderMut`]: struct.RawEntryBuilderMut.html
-pub enum RawEntryMut<'map, K, V, S> {
+pub enum RawEntryMut<'map, K, V, const N: usize, S> {
     /// An occupied entry.
-    Occupied(RawOccupiedEntryMut<'map, K, V, S>),
+    Occupied(RawOccupiedEntryMut<'map, K, V, N, S>),
     /// A vacant entry.
-    Vacant(RawVacantEntryMut<'map, K, V, S>),
+    Vacant(RawVacantEntryMut<'map, K, V, N, S>),
 }
 
-impl<'map, K, V, S> From<vecmap::RawEntryMut<'map, K, V, S>> for RawEntryMut<'map, K, V, S> {
-    fn from(e: vecmap::RawEntryMut<'map, K, V, S>) -> Self {
+impl<'map, K, V, const N: usize, S> From<vecmap::RawEntryMut<'map, K, V, N, S>>
+    for RawEntryMut<'map, K, V, N, S>
+{
+    fn from(e: vecmap::RawEntryMut<'map, K, V, N, S>) -> Self {
         match e {
             vecmap::RawEntryMut::Occupied(o) => Self::Occupied(o.into()),
             vecmap::RawEntryMut::Vacant(v) => Self::Vacant(v.into()),
@@ -64,7 +68,9 @@ impl<'map, K, V, S> From<vecmap::RawEntryMut<'map, K, V, S>> for RawEntryMut<'ma
     }
 }
 
-impl<'map, K, V, S> From<hash_map::RawEntryMut<'map, K, V, S>> for RawEntryMut<'map, K, V, S> {
+impl<'map, K, V, const N: usize, S> From<hash_map::RawEntryMut<'map, K, V, S>>
+    for RawEntryMut<'map, K, V, N, S>
+{
     fn from(e: hash_map::RawEntryMut<'map, K, V, S>) -> Self {
         match e {
             hash_map::RawEntryMut::Occupied(o) => Self::Occupied(o.into()),
@@ -77,25 +83,27 @@ impl<'map, K, V, S> From<hash_map::RawEntryMut<'map, K, V, S>> for RawEntryMut<'
 /// It is part of the [`RawEntryMut`] enum.
 ///
 /// [`RawEntryMut`]: enum.RawEntryMut.html
-pub struct RawOccupiedEntryMut<'map, K, V, S>(RawOccupiedEntryMutInt<'map, K, V, S>);
+pub struct RawOccupiedEntryMut<'map, K, V, const N: usize, S>(
+    RawOccupiedEntryMutInt<'map, K, V, N, S>,
+);
 
-impl<'map, K, V, S> From<vecmap::RawOccupiedEntryMut<'map, K, V, S>>
-    for RawOccupiedEntryMut<'map, K, V, S>
+impl<'map, K, V, const N: usize, S> From<vecmap::RawOccupiedEntryMut<'map, K, V, N, S>>
+    for RawOccupiedEntryMut<'map, K, V, N, S>
 {
-    fn from(m: vecmap::RawOccupiedEntryMut<'map, K, V, S>) -> Self {
+    fn from(m: vecmap::RawOccupiedEntryMut<'map, K, V, N, S>) -> Self {
         Self(RawOccupiedEntryMutInt::Vec(m))
     }
 }
 
-impl<'map, K, V, S> From<hash_map::RawOccupiedEntryMut<'map, K, V, S>>
-    for RawOccupiedEntryMut<'map, K, V, S>
+impl<'map, K, V, const N: usize, S> From<hash_map::RawOccupiedEntryMut<'map, K, V, S>>
+    for RawOccupiedEntryMut<'map, K, V, N, S>
 {
     fn from(m: hash_map::RawOccupiedEntryMut<'map, K, V, S>) -> Self {
         Self(RawOccupiedEntryMutInt::Map(m))
     }
 }
 
-unsafe impl<K, V, S> Send for RawOccupiedEntryMut<'_, K, V, S>
+unsafe impl<K, V, const N: usize, S> Send for RawOccupiedEntryMut<'_, K, V, N, S>
 where
     K: Send,
     V: Send,
@@ -103,7 +111,7 @@ where
 {
 }
 
-unsafe impl<K, V, S> Sync for RawOccupiedEntryMut<'_, K, V, S>
+unsafe impl<K, V, const N: usize, S> Sync for RawOccupiedEntryMut<'_, K, V, N, S>
 where
     K: Sync,
     V: Sync,
@@ -111,19 +119,19 @@ where
 {
 }
 
-enum RawOccupiedEntryMutInt<'map, K, V, S> {
-    Vec(vecmap::RawOccupiedEntryMut<'map, K, V, S>),
+enum RawOccupiedEntryMutInt<'map, K, V, const N: usize, S> {
+    Vec(vecmap::RawOccupiedEntryMut<'map, K, V, N, S>),
     Map(hash_map::RawOccupiedEntryMut<'map, K, V, S>),
 }
 
-unsafe impl<K, V, S> Send for RawOccupiedEntryMutInt<'_, K, V, S>
+unsafe impl<K, V, const N: usize, S> Send for RawOccupiedEntryMutInt<'_, K, V, N, S>
 where
     K: Send,
     V: Send,
     S: Send,
 {
 }
-unsafe impl<K, V, S> Sync for RawOccupiedEntryMutInt<'_, K, V, S>
+unsafe impl<K, V, const N: usize, S> Sync for RawOccupiedEntryMutInt<'_, K, V, N, S>
 where
     K: Sync,
     V: Sync,
@@ -135,26 +143,26 @@ where
 /// It is part of the [`RawEntryMut`] enum.
 ///
 /// [`RawEntryMut`]: enum.RawEntryMut.html
-pub struct RawVacantEntryMut<'map, K, V, S>(RawVacantEntryMutInt<'map, K, V, S>);
+pub struct RawVacantEntryMut<'map, K, V, const N: usize, S>(RawVacantEntryMutInt<'map, K, V, N, S>);
 
-impl<'map, K, V, S> From<vecmap::RawVacantEntryMut<'map, K, V, S>>
-    for RawVacantEntryMut<'map, K, V, S>
+impl<'map, K, V, const N: usize, S> From<vecmap::RawVacantEntryMut<'map, K, V, N, S>>
+    for RawVacantEntryMut<'map, K, V, N, S>
 {
-    fn from(m: vecmap::RawVacantEntryMut<'map, K, V, S>) -> Self {
+    fn from(m: vecmap::RawVacantEntryMut<'map, K, V, N, S>) -> Self {
         Self(RawVacantEntryMutInt::Vec(m))
     }
 }
 
-impl<'map, K, V, S> From<hash_map::RawVacantEntryMut<'map, K, V, S>>
-    for RawVacantEntryMut<'map, K, V, S>
+impl<'map, K, V, const N: usize, S> From<hash_map::RawVacantEntryMut<'map, K, V, S>>
+    for RawVacantEntryMut<'map, K, V, N, S>
 {
     fn from(m: hash_map::RawVacantEntryMut<'map, K, V, S>) -> Self {
         Self(RawVacantEntryMutInt::Map(m))
     }
 }
 
-enum RawVacantEntryMutInt<'map, K, V, S> {
-    Vec(vecmap::RawVacantEntryMut<'map, K, V, S>),
+enum RawVacantEntryMutInt<'map, K, V, const N: usize, S> {
+    Vec(vecmap::RawVacantEntryMut<'map, K, V, N, S>),
     Map(hash_map::RawVacantEntryMut<'map, K, V, S>),
 }
 
@@ -164,37 +172,37 @@ enum RawVacantEntryMutInt<'map, K, V, S> {
 ///
 /// [`HashMap::raw_entry`]: struct.HashMap.html#method.raw_entry
 ///
-pub struct RawEntryBuilder<'map, K, V, S>(RawEntryBuilderInt<'map, K, V, S>);
+pub struct RawEntryBuilder<'map, K, V, const N: usize, S>(RawEntryBuilderInt<'map, K, V, N, S>);
 
-impl<'map, K, V, S> From<hash_map::RawEntryBuilder<'map, K, V, S>>
-    for RawEntryBuilder<'map, K, V, S>
+impl<'map, K, V, const N: usize, S> From<hash_map::RawEntryBuilder<'map, K, V, S>>
+    for RawEntryBuilder<'map, K, V, N, S>
 {
     fn from(m: hash_map::RawEntryBuilder<'map, K, V, S>) -> Self {
         Self(RawEntryBuilderInt::Map(m))
     }
 }
 
-impl<'map, K, V, S> From<vecmap::RawEntryBuilder<'map, K, V, S>>
-    for RawEntryBuilder<'map, K, V, S>
+impl<'map, K, V, const N: usize, S> From<vecmap::RawEntryBuilder<'map, K, V, N, S>>
+    for RawEntryBuilder<'map, K, V, N, S>
 {
-    fn from(m: vecmap::RawEntryBuilder<'map, K, V, S>) -> Self {
+    fn from(m: vecmap::RawEntryBuilder<'map, K, V, N, S>) -> Self {
         Self(RawEntryBuilderInt::Vec(m))
     }
 }
 
-enum RawEntryBuilderInt<'map, K, V, S> {
-    Vec(vecmap::RawEntryBuilder<'map, K, V, S>),
+enum RawEntryBuilderInt<'map, K, V, const N: usize, S> {
+    Vec(vecmap::RawEntryBuilder<'map, K, V, N, S>),
     Map(hash_map::RawEntryBuilder<'map, K, V, S>),
 }
 
-impl<'map, K, V, S> RawEntryBuilderMut<'map, K, V, S>
+impl<'map, K, V, const N: usize, S> RawEntryBuilderMut<'map, K, V, N, S>
 where
     S: BuildHasher,
 {
     /// Creates a `RawEntryMut` from the given key.
     #[inline]
     #[allow(clippy::wrong_self_convention)]
-    pub fn from_key<Q>(self, k: &Q) -> RawEntryMut<'map, K, V, S>
+    pub fn from_key<Q>(self, k: &Q) -> RawEntryMut<'map, K, V, N, S>
     where
         K: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
@@ -208,7 +216,7 @@ where
     /// Creates a `RawEntryMut` from the given key and its hash.
     #[inline]
     #[allow(clippy::wrong_self_convention)]
-    pub fn from_key_hashed_nocheck<Q>(self, hash: u64, k: &Q) -> RawEntryMut<'map, K, V, S>
+    pub fn from_key_hashed_nocheck<Q>(self, hash: u64, k: &Q) -> RawEntryMut<'map, K, V, N, S>
     where
         K: Borrow<Q>,
         Q: Eq + ?Sized,
@@ -220,14 +228,14 @@ where
     }
 }
 
-impl<'map, K, V, S> RawEntryBuilderMut<'map, K, V, S>
+impl<'map, K, V, const N: usize, S> RawEntryBuilderMut<'map, K, V, N, S>
 where
     S: BuildHasher,
 {
     /// Creates a `RawEntryMut` from the given hash.
     #[inline]
     #[allow(clippy::wrong_self_convention)]
-    pub fn from_hash<F>(self, hash: u64, is_match: F) -> RawEntryMut<'map, K, V, S>
+    pub fn from_hash<F>(self, hash: u64, is_match: F) -> RawEntryMut<'map, K, V, N, S>
     where
         for<'b> F: FnMut(&'b K) -> bool,
     {
@@ -238,7 +246,7 @@ where
     }
 }
 
-impl<'map, K, V, S> RawEntryBuilder<'map, K, V, S>
+impl<'map, K, V, const N: usize, S> RawEntryBuilder<'map, K, V, N, S>
 where
     S: BuildHasher,
 {
@@ -284,7 +292,7 @@ where
     }
 }
 
-impl<'map, K, V, S> RawEntryMut<'map, K, V, S>
+impl<'map, K, V, const N: usize, S> RawEntryMut<'map, K, V, N, S>
 where
     S: BuildHasher,
 {
@@ -301,7 +309,7 @@ where
     /// assert_eq!(entry.remove_entry(), ("horseyland", 37));
     /// ```
     #[inline]
-    pub fn insert(self, key: K, value: V) -> RawOccupiedEntryMut<'map, K, V, S>
+    pub fn insert(self, key: K, value: V) -> RawOccupiedEntryMut<'map, K, V, N, S>
     where
         K: Hash,
         S: BuildHasher,
@@ -426,7 +434,7 @@ where
     }
 }
 
-impl<'map, K, V, S> RawOccupiedEntryMut<'map, K, V, S>
+impl<'map, K, V, const N: usize, S> RawOccupiedEntryMut<'map, K, V, N, S>
 where
     S: BuildHasher,
 {
@@ -558,7 +566,7 @@ where
     }
 }
 
-impl<'map, K, V, S> RawVacantEntryMut<'map, K, V, S>
+impl<'map, K, V, const N: usize, S> RawVacantEntryMut<'map, K, V, N, S>
 where
     S: BuildHasher,
 {
@@ -611,13 +619,13 @@ where
     }
 }
 
-impl<K, V, S> Debug for RawEntryBuilderMut<'_, K, V, S> {
+impl<K, V, const N: usize, S> Debug for RawEntryBuilderMut<'_, K, V, N, S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RawEntryBuilder").finish()
     }
 }
 
-impl<K: Debug, V: Debug, S> Debug for RawEntryMut<'_, K, V, S>
+impl<K: Debug, V: Debug, const N: usize, S> Debug for RawEntryMut<'_, K, V, N, S>
 where
     S: BuildHasher,
 {
@@ -629,7 +637,7 @@ where
     }
 }
 
-impl<K: Debug, V: Debug, S> Debug for RawOccupiedEntryMut<'_, K, V, S>
+impl<K: Debug, V: Debug, const N: usize, S> Debug for RawOccupiedEntryMut<'_, K, V, N, S>
 where
     S: BuildHasher,
 {
@@ -641,13 +649,13 @@ where
     }
 }
 
-impl<K, V, S> Debug for RawVacantEntryMut<'_, K, V, S> {
+impl<K, V, const N: usize, S> Debug for RawVacantEntryMut<'_, K, V, N, S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RawVacantEntryMut").finish()
     }
 }
 
-impl<K, V, S> Debug for RawEntryBuilder<'_, K, V, S> {
+impl<K, V, const N: usize, S> Debug for RawEntryBuilder<'_, K, V, N, S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RawEntryBuilder").finish()
     }

--- a/src/vecmap/entry.rs
+++ b/src/vecmap/entry.rs
@@ -15,15 +15,15 @@ use std::mem;
 ///
 /// [`HashMap`]: struct.HashMap.html
 /// [`entry`]: struct.HashMap.html#method.entry
-pub enum Entry<'a, K, V, S> {
+pub enum Entry<'a, K, V, const N: usize, S> {
     /// An occupied entry.
-    Occupied(OccupiedEntry<'a, K, V, S>),
+    Occupied(OccupiedEntry<'a, K, V, S, N>),
 
     /// A vacant entry.
-    Vacant(VacantEntry<'a, K, V, S>),
+    Vacant(VacantEntry<'a, K, V, N, S>),
 }
 
-impl<'a, K, V, S> Entry<'a, K, V, S> {
+impl<'a, K, V, S, const N: usize> Entry<'a, K, V, N, S> {
     /// Ensures a value is in the entry by inserting the default if empty, and returns
     /// a mutable reference to the value in the entry.
     ///
@@ -130,7 +130,7 @@ impl<'a, K, V, S> Entry<'a, K, V, S> {
     }
 }
 
-impl<K: fmt::Debug, V: fmt::Debug, S> fmt::Debug for Entry<'_, K, V, S> {
+impl<K: fmt::Debug, V: fmt::Debug, const N: usize, S> fmt::Debug for Entry<'_, K, V, N, S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Entry::Vacant(ref v) => f.debug_tuple("Entry").field(v).finish(),
@@ -143,20 +143,20 @@ impl<K: fmt::Debug, V: fmt::Debug, S> fmt::Debug for Entry<'_, K, V, S> {
 /// It is part of the [`Entry`] enum.
 ///
 /// [`Entry`]: enum.Entry.html
-pub struct OccupiedEntry<'a, K, V, S> {
+pub struct OccupiedEntry<'a, K, V, S, const N: usize> {
     idx: usize,
     key: Option<K>,
-    map: &'a mut VecMap<K, V, S>,
+    map: &'a mut VecMap<K, V, N, S>,
 }
 
-unsafe impl<K, V, S> Send for OccupiedEntry<'_, K, V, S>
+unsafe impl<K, V, S, const N: usize> Send for OccupiedEntry<'_, K, V, S, N>
 where
     K: Send,
     V: Send,
     S: Send,
 {
 }
-unsafe impl<K, V, S> Sync for OccupiedEntry<'_, K, V, S>
+unsafe impl<K, V, S, const N: usize> Sync for OccupiedEntry<'_, K, V, S, N>
 where
     K: Sync,
     V: Sync,
@@ -164,7 +164,7 @@ where
 {
 }
 
-impl<K: Debug, V: Debug, S> Debug for OccupiedEntry<'_, K, V, S> {
+impl<K: Debug, V: Debug, S, const N: usize> Debug for OccupiedEntry<'_, K, V, S, N> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("OccupiedEntry")
             .field("key", self.key())
@@ -173,8 +173,8 @@ impl<K: Debug, V: Debug, S> Debug for OccupiedEntry<'_, K, V, S> {
     }
 }
 
-impl<'a, K, V, S> OccupiedEntry<'a, K, V, S> {
-    pub(crate) fn new(idx: usize, key: K, map: &'a mut VecMap<K, V, S>) -> Self {
+impl<'a, K, V, S, const N: usize> OccupiedEntry<'a, K, V, S, N> {
+    pub(crate) fn new(idx: usize, key: K, map: &'a mut VecMap<K, V, N, S>) -> Self {
         Self {
             idx,
             key: Some(key),
@@ -414,19 +414,19 @@ impl<'a, K, V, S> OccupiedEntry<'a, K, V, S> {
 /// It is part of the [`Entry`] enum.
 ///
 /// [`Entry`]: enum.Entry.html
-pub struct VacantEntry<'a, K, V, S> {
+pub struct VacantEntry<'a, K, V, const N: usize, S> {
     key: K,
-    map: &'a mut VecMap<K, V, S>,
+    map: &'a mut VecMap<K, V, N, S>,
 }
 
-impl<K: Debug, V, S> Debug for VacantEntry<'_, K, V, S> {
+impl<K: Debug, V, const N: usize, S> Debug for VacantEntry<'_, K, V, N, S> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("VacantEntry").field(self.key()).finish()
     }
 }
 
-impl<'a, K, V, S> VacantEntry<'a, K, V, S> {
-    pub(crate) fn new(key: K, map: &'a mut VecMap<K, V, S>) -> Self {
+impl<'a, K, V, const N: usize, S> VacantEntry<'a, K, V, N, S> {
+    pub(crate) fn new(key: K, map: &'a mut VecMap<K, V, N, S>) -> Self {
         Self { key, map }
     }
     /// Gets a reference to the key that would be used when inserting a value

--- a/src/vecmap/iter.rs
+++ b/src/vecmap/iter.rs
@@ -1,11 +1,12 @@
 use super::VecMap;
+use crate::vectypes::VecIntoIter;
 
-impl<K, V, S> IntoIterator for VecMap<K, V, S> {
+impl<K, V, const N: usize, S> IntoIterator for VecMap<K, V, N, S> {
     type Item = (K, V);
-    type IntoIter = std::vec::IntoIter<(K, V)>;
+    type IntoIter = VecIntoIter<(K, V), N>;
 
     #[inline]
-    fn into_iter(self) -> std::vec::IntoIter<(K, V)> {
+    fn into_iter(self) -> Self::IntoIter {
         self.v.into_iter()
     }
 }

--- a/src/vectypes.rs
+++ b/src/vectypes.rs
@@ -1,0 +1,9 @@
+#[cfg(not(feature = "arraybackend"))]
+pub(crate) type VecDrain<'a, T, const N: usize> = std::vec::Drain<'a, T>;
+#[cfg(feature = "arraybackend")]
+pub(crate) type VecDrain<'a, T, const N: usize> = arrayvec::Drain<'a, T, N>;
+
+#[cfg(not(feature = "arraybackend"))]
+pub(crate) type VecIntoIter<T, const N: usize> = std::vec::IntoIter<T>;
+#[cfg(feature = "arraybackend")]
+pub(crate) type VecIntoIter<T, const N: usize> = arrayvec::IntoIter<T, N>;


### PR DESCRIPTION
This PR adds a feature **arraybackend** to store the Vec backend on the stack via the crate arrayvec. It closes #20.
Furthermore, in the 2nd commit I have **removed the HashMapInt:None** variant which as far as I understand is an artefact of old capabilities of the borrow checker?
The 3rd commit adds testing for the arraybackend feature to the github workflows.

Major changes that were made:

- New feature **arraybackend** that uses arrayvec as backend
-  New file vectypes.rs that defines types like `IntoIter` depending on whether the new feature was opted into.
- `.entry()` and `.insert_nocheck()` now switch to map backend when necessary. Every call to these functions now needs to check how many elements are in the map. The only alternative to that would be to completely rewrite the relevant Entry structs.
- Added new tests to ensure that the map always switches to a map backend indepent of which function you use to add entries( `insert`, `entry`, or `insert_nocheck`). This is crucial since arrayvec will panic if you push beyond its capacity.
- `.reserve()` and `.shrink_to_fit()` don't make sense for the arraybackend and won't do anything when called. I guess they should be there for API compatibility.

Am I correct that `insert`, `entry`, or `insert_nocheck` are the only functions that can add entries?,if not then the other functions need to be checked as well that they never push beyond the limit. 

I am sorry that the PR will be hard to review since I had to add const N : usize to basically every enum and struct.
