### PR TITLE
support from_iter/into_iter for generic SizedHashMap

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -139,7 +139,7 @@ impl<K, V, const N: usize, S> IntoIterator for SizedHashMap<K, V, S, N> {
     }
 }
 
-impl<'a, K, V, S> IntoIterator for &'a SizedHashMap<K, V, S> {
+impl<'a, K, V, S, const N: usize> IntoIterator for &'a SizedHashMap<K, V, S, N> {
     type Item = (&'a K, &'a V);
     type IntoIter = Iter<'a, K, V>;
 
@@ -149,7 +149,7 @@ impl<'a, K, V, S> IntoIterator for &'a SizedHashMap<K, V, S> {
     }
 }
 
-impl<K, V, S> FromIterator<(K, V)> for SizedHashMap<K, V, S>
+impl<K, V, S, const N: usize> FromIterator<(K, V)> for SizedHashMap<K, V, S, N>
 where
     K: Eq + Hash,
     S: BuildHasher + Default,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1088,7 +1088,7 @@ mod tests {
     fn scale_up() {
         let mut v = SizedHashMap::<_, _, _, TEST_SIZE>::new();
         assert!(v.is_vec());
-        for i in 1..TEST_SIZE + 1 {
+        for i in 1..=TEST_SIZE {
             v.insert(i, i);
             assert!(v.is_vec());
         }
@@ -1100,7 +1100,7 @@ mod tests {
     fn scale_up_via_entry() {
         let mut v = SizedHashMap::<_, _, _, TEST_SIZE>::new();
         assert!(v.is_vec());
-        for i in 1..TEST_SIZE + 1 {
+        for i in 1..=TEST_SIZE {
             v.entry(i).or_insert(i);
             assert!(v.is_vec());
         }


### PR DESCRIPTION
This PR implemented `IntoIterator` for `&'a SizedHashMap` and `FromIterator` for `SizedHashMap` that has different length with the default vector length `N`. 