### PR TITLE
indexmap feature for ordered 33+ key maps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ hashbrown = "0.16"
 rustc-hash = { version = "2.1", optional = true }
 serde = { version = "1", default-features = false, optional = true }
 arrayvec = { version = "0.7", optional = true }
+indexmap = { version = "2", optional = true }
 [dev-dependencies]
 criterion = "0.5"
 
@@ -20,6 +21,7 @@ criterion = "0.5"
 default = []
 fxhash = ["rustc-hash"]
 arraybackend = ["arrayvec"]
+indexmap = ["dep:indexmap"]
 
 [[bench]]
 harness = false

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -22,7 +22,10 @@ impl<'a, K, V> From<IterInt<'a, K, V>> for Iter<'a, K, V> {
 
 #[derive(Debug)]
 pub(crate) enum IterInt<'a, K, V> {
+    #[cfg(not(feature = "indexmap"))]
     Map(hashbrown::hash_map::Iter<'a, K, V>),
+    #[cfg(feature = "indexmap")]
+    Map(indexmap::map::Iter<'a, K, V>),
     Vec(std::slice::Iter<'a, (K, V)>),
 }
 
@@ -76,7 +79,10 @@ impl<K, V> FusedIterator for Iter<'_, K, V> {}
 pub struct IntoIter<K, V, const N: usize>(IntoIterInt<K, V, N>);
 
 enum IntoIterInt<K, V, const N: usize> {
+    #[cfg(not(feature = "indexmap"))]
     Map(hashbrown::hash_map::IntoIter<K, V>),
+    #[cfg(feature = "indexmap")]
+    Map(indexmap::map::IntoIter<K, V>),
     Vec(VecIntoIter<(K, V), N>),
 }
 
@@ -89,7 +95,7 @@ impl<K, V, const N: usize> IntoIter<K, V, N> {
             IntoIterInt::Vec(i) => i.len(),
         }
     }
-    /// If this iteratoris empty
+    /// If this iterator is empty
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
@@ -185,7 +191,10 @@ impl<'a, K, V> From<IterMutInt<'a, K, V>> for IterMut<'a, K, V> {
 }
 
 pub(crate) enum IterMutInt<'a, K, V> {
+    #[cfg(not(feature = "indexmap"))]
     Map(hashbrown::hash_map::IterMut<'a, K, V>),
+    #[cfg(feature = "indexmap")]
+    Map(indexmap::map::IterMut<'a, K, V>),
     Vec(std::slice::IterMut<'a, (K, V)>),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1145,4 +1145,18 @@ mod tests {
         assert_eq!(v.get(&2), None);
         assert_eq!(v.get(&3), Some(&3));
     }
+
+    #[cfg(feature = "indexmap")]
+    #[test]
+    fn test_insertion_order_preserved() {
+        let mut map = SizedHashMap::<i32, i32, _, 32>::new();
+        for i in 0..33 {
+            map.insert(i, i * 10);
+        }
+        // Map should have switched to hashmap backend at 33 elements
+        assert!(map.is_map());
+        let iterated_keys: Vec<i32> = map.iter().map(|(k, _)| *k).collect();
+        let expected_keys: Vec<i32> = (0..33).collect();
+        assert_eq!(iterated_keys, expected_keys);
+    }
 }

--- a/src/vecmap.rs
+++ b/src/vecmap.rs
@@ -93,6 +93,7 @@ impl<K, V, const N: usize, S> VecMap<K, V, N, S> {
         Self { v, hash_builder }
     }
 
+    #[cfg(not(feature = "indexmap"))]
     #[inline]
     pub fn retain<F>(&mut self, mut f: F)
     where
@@ -298,6 +299,7 @@ impl<K, V, const N: usize, S> VecMap<K, V, N, S> {
     /// so that the map now contains keys which compare equal, search may start
     /// acting erratically, with two keys randomly masking each other. Implementations
     /// are free to assume this doesn't happen (within the limits of memory-safety).
+    #[cfg(not(feature = "indexmap"))]
     #[inline]
     pub fn raw_entry_mut(&mut self) -> RawEntryBuilderMut<'_, K, V, N, S> {
         RawEntryBuilderMut { map: self }
@@ -318,6 +320,7 @@ impl<K, V, const N: usize, S> VecMap<K, V, N, S> {
     /// `get` should be preferred.
     ///
     /// Immutable raw entries have very limited use; you might instead want `raw_entry_mut`.
+    #[cfg(not(feature = "indexmap"))]
     #[inline]
     pub fn raw_entry(&self) -> RawEntryBuilder<'_, K, V, N, S> {
         RawEntryBuilder { map: self }
@@ -348,6 +351,7 @@ impl<K, V, const N: usize, S> VecMap<K, V, N, S> {
         arrayvec::ArrayVec::new()
     }
     #[cfg(not(feature = "arraybackend"))]
+    #[cfg(not(feature = "indexmap"))]
     #[inline]
     fn make_empty_vec_backend() -> Vec<(K, V)> {
         Vec::new()

--- a/src/vecmap.rs
+++ b/src/vecmap.rs
@@ -346,6 +346,7 @@ impl<K, V, const N: usize, S> VecMap<K, V, N, S> {
         (&mut r.0, &mut r.1)
     }
     #[cfg(feature = "arraybackend")]
+    #[cfg(not(feature = "indexmap"))]
     #[inline]
     fn make_empty_vec_backend() -> arrayvec::ArrayVec<(K, V), N> {
         arrayvec::ArrayVec::new()


### PR DESCRIPTION
I found out today that indexmap was discussed a year ago [for use downstream in simd-json](https://github.com/simd-lite/simd-json/issues/378) but then there wasn't development in support of it and it got forgotten.

I have provided a simple implementation that swaps out the use of the hashbrown `HashMap` for an indexmap `IndexMap`, with as many of the methods as it provides (for instance it does not provide a replace entry method and closed a [request](https://github.com/indexmap-rs/indexmap/issues/362) for one as unplanned).

I can open an issue to accompany this if you'd like to discuss the motivation/design more, or I'm happy to use this PR for specific asks.

- I include a simple concise test in the house style, that failed initially and then succeeded after making the changes
  - The tests pass with just the indexmap feature, as well as: with fxhash; with arraybackend; with both fxhash/arraybackend
- Compilation does not produce warnings or errors (as well as in the feature flag combinations above)